### PR TITLE
Support JUJU_TERMS, production default URL.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/terms-client/api/wireformat"
 )
 
-var BaseURL = "https://api.jujucharms.com/terms"
+var defaultURL = "https://api.jujucharms.com/terms"
 
 // Client represents the interface of the terms service client ap client apii.
 type Client interface {
@@ -80,7 +80,7 @@ func ServiceURL(serviceURL string) ClientOption {
 func NewClient(options ...ClientOption) (Client, error) {
 	bakeryClient := httpbakery.NewClient()
 	c := &client{
-		serviceURL: getBaseURL(),
+		serviceURL: BaseURL(),
 		bclient:    bakeryClient,
 	}
 	for _, option := range options {
@@ -344,8 +344,8 @@ func (c *client) GetUnsignedTerms(terms *wireformat.CheckAgreementsRequest) ([]w
 	return results, nil
 }
 
-func getBaseURL() string {
-	baseURL := BaseURL
+func BaseURL() string {
+	baseURL := defaultURL
 	if termsURL := os.Getenv("JUJU_TERMS"); termsURL != "" {
 		baseURL = termsURL
 	}

--- a/api/env_test.go
+++ b/api/env_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"os"
+
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&envSuite{})
+
+type envSuite struct {
+	jujutesting.OsEnvSuite
+}
+
+func (s *envSuite) TestDefault(c *gc.C) {
+	c.Assert(BaseURL(), gc.Equals, defaultURL)
+}
+
+func (s *envSuite) TestEnvOverrides(c *gc.C) {
+	os.Setenv("JUJU_TERMS", "something-else")
+	c.Assert(BaseURL(), gc.Equals, "something-else")
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,6 +8,14 @@ import (
 
 	"github.com/juju/cmd"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/terms-client/api"
+)
+
+var (
+	clientNew = func(options ...api.ClientOption) (api.Client, error) {
+		return api.NewClient(options...)
+	}
 )
 
 type commandWithDescription interface {

--- a/cmd/publish_term.go
+++ b/cmd/publish_term.go
@@ -40,8 +40,6 @@ type publishTermCommand struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *publishTermCommand) SetFlags(f *gnuflag.FlagSet) {
-	// TODO (mattyw) JUJU_TERMS
-	f.StringVar(&c.TermsServiceLocation, "url", defaultTermServiceLocation, "url of the terms service")
 	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
 }
 
@@ -62,6 +60,7 @@ func (c *publishTermCommand) Description() string {
 
 // Init reads and verifies the arguments.
 func (c *publishTermCommand) Init(args []string) error {
+	c.TermsServiceLocation = api.BaseURL()
 	if len(args) < 1 {
 		return errors.New("missing arguments")
 	}

--- a/cmd/push_term.go
+++ b/cmd/push_term.go
@@ -20,13 +20,7 @@ import (
 	"github.com/juju/terms-client/api"
 )
 
-var (
-	defaultTermServiceLocation = "http://localhost:8081"
-	readFile                   = ioutil.ReadFile
-	clientNew                  = func(options ...api.ClientOption) (api.Client, error) {
-		return api.NewClient(options...)
-	}
-)
+var readFile = ioutil.ReadFile
 
 const pushTermDoc = `
 push-term is used to create a new Terms and Conditions document.
@@ -57,8 +51,6 @@ type pushTermCommand struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *pushTermCommand) SetFlags(f *gnuflag.FlagSet) {
-	// TODO (mattyw) Replace with JUJU_TERMS
-	f.StringVar(&c.TermsServiceLocation, "url", defaultTermServiceLocation, "url of the terms service")
 	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
 }
 
@@ -74,6 +66,7 @@ func (c *pushTermCommand) Info() *cmd.Info {
 
 // Init read and verifies the arguments.
 func (c *pushTermCommand) Init(args []string) error {
+	c.TermsServiceLocation = api.BaseURL()
 	if len(args) < 2 {
 		return errors.New("missing arguments")
 	}

--- a/cmd/show_term.go
+++ b/cmd/show_term.go
@@ -42,8 +42,6 @@ type showTermCommand struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *showTermCommand) SetFlags(f *gnuflag.FlagSet) {
-	// TODO (mattyw) Use JUJU_TERMS
-	f.StringVar(&c.TermsServiceLocation, "url", defaultTermServiceLocation, "url of the terms service")
 	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
 }
 
@@ -59,6 +57,7 @@ func (c *showTermCommand) Info() *cmd.Info {
 
 // Init reads and verifies the arguments.
 func (c *showTermCommand) Init(args []string) error {
+	c.TermsServiceLocation = api.BaseURL()
 	if len(args) < 1 {
 		return errors.New("missing arguments")
 	}


### PR DESCRIPTION
Remove --url flag for parity with charmstore client.
Organize globals.