### PR TITLE
Add --content switch to just show the term content text.

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -122,6 +122,11 @@ func (s *commandSuite) TestShowTerm(c *gc.C) {
 `,
 		apiCall: []interface{}{"", "test-term", 1},
 	}, {
+		about:   "everything works for content",
+		args:    []string{"test-term/1", "--content"},
+		stdout:  `Test Terms and Conditions`,
+		apiCall: []interface{}{"", "test-term", 1},
+	}, {
 		about: "everything works in yaml",
 		args:  []string{"test-term/1", "--format", "yaml"},
 		stdout: `id: test-term/1

--- a/cmd/show_term.go
+++ b/cmd/show_term.go
@@ -38,11 +38,13 @@ type showTermCommand struct {
 
 	TermID               string
 	TermsServiceLocation string
+	ShowContent          bool
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *showTermCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
+	f.BoolVar(&c.ShowContent, "content", false, "show term contents")
 }
 
 // Info implements Command.Info.
@@ -105,7 +107,11 @@ func (c *showTermCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	err = c.out.Write(ctx, response)
+	if c.ShowContent {
+		_, err = ctx.Stdout.Write([]byte(response.Content))
+	} else {
+		err = c.out.Write(ctx, response)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
I don't know if it's pretty, but it's pretty useful.