### PR TITLE
Remove plugin wrapper.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,11 +4,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/juju/cmd"
-	"github.com/juju/gnuflag"
-
 	"github.com/juju/terms-client/api"
 )
 
@@ -17,41 +12,3 @@ var (
 		return api.NewClient(options...)
 	}
 )
-
-type commandWithDescription interface {
-	cmd.Command
-	Description() string
-}
-
-// WrapPlugin returns a wrapped plugin command.
-func WrapPlugin(cmd commandWithDescription) cmd.Command {
-	return &pluginWrapper{commandWithDescription: cmd}
-}
-
-type pluginWrapper struct {
-	commandWithDescription
-	Description bool
-}
-
-// SetFlags implements Command.SetFlags.
-func (c *pluginWrapper) SetFlags(f *gnuflag.FlagSet) {
-	c.commandWithDescription.SetFlags(f)
-	f.BoolVar(&c.Description, "description", false, "returns command description")
-}
-
-// Init implements Command.Init.
-func (c *pluginWrapper) Init(args []string) error {
-	if c.Description {
-		return nil
-	}
-	return c.commandWithDescription.Init(args)
-}
-
-// Run implements Command.Run.
-func (c *pluginWrapper) Run(ctx *cmd.Context) error {
-	if c.Description {
-		fmt.Fprint(ctx.Stdout, c.commandWithDescription.Description())
-		return nil
-	}
-	return c.commandWithDescription.Run(ctx)
-}

--- a/cmd/list_terms.go
+++ b/cmd/list_terms.go
@@ -38,7 +38,7 @@ list-terms --groups test-group1,test-group2
 // NewListTermsCommand returns a new command that can be used
 // to list owned Terms and Conditions documents.
 func NewListTermsCommand() cmd.Command {
-	return WrapPlugin(&listTermsCommand{})
+	return &listTermsCommand{}
 }
 
 type listTermsCommand struct {

--- a/cmd/publish_term.go
+++ b/cmd/publish_term.go
@@ -27,7 +27,7 @@ const publishTermPurpose = "releases the given terms document"
 // used to publish existing owner terms
 // Conditions documents.
 func NewReleaseTermCommand() cmd.Command {
-	return WrapPlugin(&releaseTermCommand{})
+	return &releaseTermCommand{}
 }
 
 type releaseTermCommand struct {

--- a/cmd/push_term.go
+++ b/cmd/push_term.go
@@ -36,7 +36,7 @@ const pushTermPurpose = "create new Terms and Conditions document (revision)"
 // used to create new (revisions) of Terms and
 // Conditions documents.
 func NewPushTermCommand() cmd.Command {
-	return WrapPlugin(&pushTermCommand{})
+	return &pushTermCommand{}
 }
 
 // pushTermCommand creates a new Terms and Conditions document.

--- a/cmd/show_term.go
+++ b/cmd/show_term.go
@@ -29,7 +29,7 @@ const showTermPurpose = "shows the specified term"
 // NewShowTermCommand returns a new command that can be used
 // to shows Terms and Conditions document.
 func NewShowTermCommand() cmd.Command {
-	return WrapPlugin(&showTermCommand{})
+	return &showTermCommand{}
 }
 
 type showTermCommand struct {


### PR DESCRIPTION
Remove the plugin wrapper from command constructors, as these commands are going to be compiled into charmstore-client. See juju/charmstore-client#149.